### PR TITLE
fix: handle search API 404

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,8 +28,9 @@ def test_api():
         'timestamp': time.strftime('%Y-%m-%d %H:%M:%S')
     })
 
-@app.route('/api/search-trades', methods=['POST'])
+@app.route('/api/search-trades', methods=['GET', 'POST'], strict_slashes=False)
 def search_trades():
+    """Executa a análise completa e retorna oportunidades de trade."""
     print("🔍 [API] Iniciando busca de oportunidades no mercado de criptomoedas...")
     try:
         print("🔍 Iniciando análise completa do mercado de criptomoedas...")

--- a/app_fast.py
+++ b/app_fast.py
@@ -127,8 +127,9 @@ def test_api():
         'timestamp': time.strftime('%Y-%m-%d %H:%M:%S')
     })
 
-@app.route('/api/search-trades', methods=['POST'])
+@app.route('/api/search-trades', methods=['GET', 'POST'], strict_slashes=False)
 def search_trades():
+    """Endpoint que executa a busca por oportunidades de trade."""
     print("🔍 [API] Iniciando busca de oportunidades...")
     try:
         print("🔍 Executando análise completa das top 30 criptomoedas...")

--- a/app_simple.py
+++ b/app_simple.py
@@ -14,8 +14,9 @@ def index():
     """Página principal da interface"""
     return render_template('index.html')
 
-@app.route('/api/search-trades', methods=['POST'])
+@app.route('/api/search-trades', methods=['GET', 'POST'], strict_slashes=False)
 def search_trades():
+    """Simula a busca por oportunidades de trade."""
     print("🔍 [API] Iniciando busca de oportunidades...")
     try:
         # Simular análise rápida para teste

--- a/debug_app.py
+++ b/debug_app.py
@@ -19,18 +19,20 @@ def test_api_directly():
         
         # Teste 2: Testar a API de busca
         print("\n2. Testando API de busca...")
-        response = requests.post(
+        response = requests.get(
             'http://localhost:5000/api/search-trades',
             headers={'Content-Type': 'application/json'},
             timeout=30
         )
-        
+
         print(f"   Status: {response.status_code}")
         print(f"   Headers: {dict(response.headers)}")
-        
+
         if response.status_code == 200:
             data = response.json()
             print(f"   Resposta: {json.dumps(data, indent=2)}")
+        elif response.status_code == 404:
+            print("   Erro: endpoint /api/search-trades não encontrado")
         else:
             print(f"   Erro: {response.text}")
             

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -38,7 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
         .then(response => {
             clearTimeout(timeoutId);
             if (!response.ok) {
-                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                const statusText = response.statusText ? `: ${response.statusText}` : '';
+                throw new Error(`HTTP ${response.status}${statusText}`);
             }
             return response.json();
         })


### PR DESCRIPTION
## Summary
- handle `/api/search-trades` via GET and POST requests for all app versions
- improve debug script and frontend error message for missing endpoints

## Testing
- `pytest`
- `curl -i http://localhost:5000/api/search-trades`

------
https://chatgpt.com/codex/tasks/task_e_68940ece72c883288e1f76d37d81e67b