### PR TITLE
Fix Netlify deploy path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  publish = "templates"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ Flask==3.1.1
 numpy==2.3.2
 pandas==2.3.1
 pycoingecko==3.2.0
-Requests==2.32.4
-scikit_learn==1.7.1
+requests==2.32.4
+scikit-learn==1.7.1
 scipy==1.16.1


### PR DESCRIPTION
## Summary
- point Netlify publish directory at `templates`
- standardize package names for requests and scikit-learn

## Testing
- `pytest` *(fails: KeyboardInterrupt)*
- `pytest test_coin_count.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68941243793c832887cc795cfaad41bd